### PR TITLE
Lazy run interval

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,14 +1,18 @@
 var tick = 1
 var maxTick = 65535
 var resolution = 4
+var timer
 var inc = function () {
   tick = (tick + 1) & maxTick
 }
 
-var timer = setInterval(inc, (1000 / resolution) | 0)
-if (timer.unref) timer.unref()
 
 module.exports = function (seconds) {
+  if (!timer) {
+    timer = setInterval(inc, (1000 / resolution) | 0)
+    if (timer.unref) timer.unref()
+  }
+
   var size = resolution * (seconds || 5)
   var buffer = [0]
   var pointer = 1


### PR DESCRIPTION
Do not run interval on module import, but when we call the function. 

Some SPA frameworks (like Angular) detect this timer call and run a change detection every 250ms. Now we run the timer only when we call the function, we have a way to say to the framework "execute the speedometer function but don't check the DOM when `setInterval` is fired."